### PR TITLE
[WIP]: Add Royalty (ERC2981) Support to OptimismMintableERC721

### DIFF
--- a/packages/contracts-bedrock/src/universal/OptimismMintableERC721Factory.sol
+++ b/packages/contracts-bedrock/src/universal/OptimismMintableERC721Factory.sol
@@ -20,7 +20,8 @@ contract OptimismMintableERC721Factory is ISemver {
     /// @param localToken  Address of the token on the this domain.
     /// @param remoteToken Address of the token on the remote domain.
     /// @param deployer    Address of the initiator of the deployment
-    event OptimismMintableERC721Created(address indexed localToken, address indexed remoteToken, address deployer);
+    /// @param owner       Address of the owner of the token.
+    event OptimismMintableERC721Created(address indexed localToken, address indexed remoteToken, address deployer, address owner);
 
     /// @notice Semantic version.
     /// @custom:semver 1.4.0
@@ -40,10 +41,12 @@ contract OptimismMintableERC721Factory is ISemver {
     /// @param _remoteToken Address of the corresponding token on the other domain.
     /// @param _name        ERC721 name.
     /// @param _symbol      ERC721 symbol.
+    /// @param _owner       Address of the owner.
     function createOptimismMintableERC721(
         address _remoteToken,
         string memory _name,
-        string memory _symbol
+        string memory _symbol,
+        address _owner
     )
         external
         returns (address)
@@ -52,10 +55,10 @@ contract OptimismMintableERC721Factory is ISemver {
 
         bytes32 salt = keccak256(abi.encode(_remoteToken, _name, _symbol));
         address localToken =
-            address(new OptimismMintableERC721{ salt: salt }(BRIDGE, REMOTE_CHAIN_ID, _remoteToken, _name, _symbol));
+            address(new OptimismMintableERC721{ salt: salt }(BRIDGE, REMOTE_CHAIN_ID, _remoteToken, _name, _symbol, _owner));
 
         isOptimismMintableERC721[localToken] = true;
-        emit OptimismMintableERC721Created(localToken, _remoteToken, msg.sender);
+        emit OptimismMintableERC721Created(localToken, _remoteToken, msg.sender, _owner);
 
         return localToken;
     }

--- a/packages/contracts-bedrock/test/L2/L2ERC721Bridge.t.sol
+++ b/packages/contracts-bedrock/test/L2/L2ERC721Bridge.t.sol
@@ -27,7 +27,7 @@ contract TestMintableERC721 is OptimismMintableERC721 {
         address _bridge,
         address _remoteToken
     )
-        OptimismMintableERC721(_bridge, 1, _remoteToken, "Test", "TST")
+        OptimismMintableERC721(_bridge, 1, _remoteToken, "Test", "TST", address(0))
     { }
 
     function mint(address to, uint256 tokenId) public {

--- a/packages/contracts-bedrock/test/universal/OptimismMintableERC721.t.sol
+++ b/packages/contracts-bedrock/test/universal/OptimismMintableERC721.t.sol
@@ -23,7 +23,7 @@ contract OptimismMintableERC721_Test is Bridge_Initializer {
 
         // Set up the token pair.
         L1NFT = new ERC721("L1NFT", "L1T");
-        L2NFT = new OptimismMintableERC721(address(l2ERC721Bridge), 1, address(L1NFT), "L2NFT", "L2T");
+        L2NFT = new OptimismMintableERC721(address(l2ERC721Bridge), 1, address(L1NFT), "L2NFT", "L2T", address(0));
 
         // Label the addresses for nice traces.
         vm.label(address(L1NFT), "L1ERC721Token");

--- a/packages/contracts-bedrock/test/universal/OptimismMintableERC721Factory.t.sol
+++ b/packages/contracts-bedrock/test/universal/OptimismMintableERC721Factory.t.sol
@@ -37,7 +37,7 @@ contract OptimismMintableERC721Factory_Test is Bridge_Initializer {
         // Create the token.
         vm.prank(alice);
         OptimismMintableERC721 created =
-            OptimismMintableERC721(factory.createOptimismMintableERC721(remote, "L2Token", "L2T"));
+            OptimismMintableERC721(factory.createOptimismMintableERC721(remote, "L2Token", "L2T", address(0)));
 
         // Token address should be correct.
         assertEq(address(created), local);
@@ -57,18 +57,18 @@ contract OptimismMintableERC721Factory_Test is Bridge_Initializer {
         address remote = address(1234);
 
         vm.prank(alice);
-        factory.createOptimismMintableERC721(remote, "L2Token", "L2T");
+        factory.createOptimismMintableERC721(remote, "L2Token", "L2T", address(0));
 
         vm.expectRevert(bytes(""));
 
         vm.prank(alice);
-        factory.createOptimismMintableERC721(remote, "L2Token", "L2T");
+        factory.createOptimismMintableERC721(remote, "L2Token", "L2T", address(0));
     }
 
     function test_createOptimismMintableERC721_zeroRemoteToken_reverts() external {
         // Try to create a token with a zero remote token address.
         vm.expectRevert("OptimismMintableERC721Factory: L1 token address cannot be address(0)");
-        factory.createOptimismMintableERC721(address(0), "L2Token", "L2T");
+        factory.createOptimismMintableERC721(address(0), "L2Token", "L2T", address(0));
     }
 
     function calculateTokenAddress(
@@ -80,9 +80,9 @@ contract OptimismMintableERC721Factory_Test is Bridge_Initializer {
         view
         returns (address)
     {
-        bytes memory constructorArgs = abi.encode(address(l2ERC721Bridge), 1, _remote, _name, _symbol);
+        bytes memory constructorArgs = abi.encode(address(l2ERC721Bridge), 1, _remote, _name, _symbol, address(0));
         bytes memory bytecode = abi.encodePacked(type(OptimismMintableERC721).creationCode, constructorArgs);
-        bytes32 salt = keccak256(abi.encode(_remote, _name, _symbol));
+        bytes32 salt = keccak256(abi.encode(_remote, _name, _symbol, address(0)));
         bytes32 hash = keccak256(abi.encodePacked(bytes1(0xff), address(factory), salt, keccak256(bytecode)));
         return address(uint160(uint256(hash)));
     }


### PR DESCRIPTION
Updates the `OptimismMintableERC721` and `OptimismMintableERC721Factory` smart contracts to add support for ERC2981 i.e. royalities.

A featured requested by multiple L1 NFT projects before they migrate collections to the Superchain.

> [!IMPORTANT]  
> Structure may change before a PR is made to the [@ethereum-optimism/optimism](https://github.com/ethereum-optimism/optimism) repo after more feedback.